### PR TITLE
Add multizone local dev basePath override

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,9 +1,16 @@
 import type { NextConfig } from "next";
 
+const configuredBasePath = process.env.NEXT_PUBLIC_BASE_PATH;
+const basePath =
+  configuredBasePath === ""
+    ? undefined
+    : configuredBasePath || "/us/watca";
+const publicBasePath = configuredBasePath === "" ? "" : basePath || "";
+
 const nextConfig: NextConfig = {
-  basePath: "/us/watca",
+  ...(basePath ? { basePath } : {}),
   env: {
-    NEXT_PUBLIC_BASE_PATH: "/us/watca",
+    NEXT_PUBLIC_BASE_PATH: publicBasePath,
   },
   poweredByHeader: false,
   async headers() {


### PR DESCRIPTION
## Summary
- make the WATCA base path configurable through NEXT_PUBLIC_BASE_PATH
- preserve the production default of /us/watca
- allow NEXT_PUBLIC_BASE_PATH="" for local next dev without the multizone path

## Verification
- bun run build
