### PR TITLE
Restore teal hero (inline design-token hex values)

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -37,10 +37,10 @@
   --color-secondary-800: #1E293B;
   --color-secondary-900: #101828;
 
-  --color-success: #166534;
+  --color-success: #22C55E;
   --color-warning: #FEC601;
   --color-error: #EF4444;
-  --color-info: #2C7A7B;
+  --color-info: #1890FF;
 
   --font-sans:
     Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -3,41 +3,53 @@
 @import "tailwindcss";
 @import "../node_modules/@policyengine/ui-kit/dist/styles.css";
 
+/*
+ * @theme maps PolicyEngine design-token hex values onto Tailwind v4 utility
+ * classes (bg-primary-500, text-secondary-700, etc.).
+ *
+ * Values are inlined from @policyengine/design-system 0.3.0 tokens.css.
+ * They used to come through `var(--pe-color-*)` aliases shipped by that
+ * package's tokens.css, but @policyengine/ui-kit/legacy is a JS-only compat
+ * shim and does not ship the CSS variables — so leaving the var() references
+ * here resolves to *undefined*, which is why the hero rendered as white on
+ * white before this change.
+ */
 @theme {
-  /* Map PE design system colors to Tailwind theme */
-  --color-primary-50: var(--pe-color-primary-50);
-  --color-primary-100: var(--pe-color-primary-100);
-  --color-primary-200: var(--pe-color-primary-200);
-  --color-primary-300: var(--pe-color-primary-300);
-  --color-primary-400: var(--pe-color-primary-400);
-  --color-primary-500: var(--pe-color-primary-500);
-  --color-primary-600: var(--pe-color-primary-600);
-  --color-primary-700: var(--pe-color-primary-700);
-  --color-primary-800: var(--pe-color-primary-800);
-  --color-primary-900: var(--pe-color-primary-900);
+  --color-primary-50: #E6FFFA;
+  --color-primary-100: #B2F5EA;
+  --color-primary-200: #81E6D9;
+  --color-primary-300: #4FD1C5;
+  --color-primary-400: #38B2AC;
+  --color-primary-500: #319795;
+  --color-primary-600: #2C7A7B;
+  --color-primary-700: #285E61;
+  --color-primary-800: #234E52;
+  --color-primary-900: #1D4044;
 
   --color-secondary-50: #F0F9FF;
-  --color-secondary-100: var(--pe-color-gray-100);
-  --color-secondary-200: var(--pe-color-gray-200);
-  --color-secondary-300: var(--pe-color-gray-300);
-  --color-secondary-400: var(--pe-color-gray-400);
-  --color-secondary-500: var(--pe-color-gray-500);
-  --color-secondary-600: var(--pe-color-gray-600);
-  --color-secondary-700: var(--pe-color-gray-700);
+  --color-secondary-100: #F2F4F7;
+  --color-secondary-200: #E2E8F0;
+  --color-secondary-300: #D1D5DB;
+  --color-secondary-400: #9CA3AF;
+  --color-secondary-500: #6B7280;
+  --color-secondary-600: #4B5563;
+  --color-secondary-700: #344054;
   --color-secondary-800: #1E293B;
-  --color-secondary-900: var(--pe-color-gray-900);
+  --color-secondary-900: #101828;
 
-  --color-success: var(--pe-color-success);
-  --color-warning: var(--pe-color-warning);
-  --color-error: var(--pe-color-error);
-  --color-info: var(--pe-color-info);
+  --color-success: #166534;
+  --color-warning: #FEC601;
+  --color-error: #EF4444;
+  --color-info: #2C7A7B;
 
-  --font-sans: var(--pe-font-family-primary);
-  --font-mono: var(--pe-font-family-mono);
+  --font-sans:
+    Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono: "JetBrains Mono", "Fira Code", Consolas, monospace;
 }
 
 body {
-  font-family: var(--pe-font-family-primary);
-  color: var(--pe-color-text-primary);
-  background-color: var(--pe-color-bg-secondary);
+  font-family:
+    Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  color: #000000;
+  background-color: #F5F9FF;
 }


### PR DESCRIPTION
## Summary
The `@theme` block in `frontend/app/globals.css` referenced `var(--pe-color-primary-500)` and ~25 other `--pe-color-*` / `--pe-font-*` variables. Those used to be defined by `@policyengine/design-system/dist/tokens.css`. PR #24 swapped that import for `@policyengine/ui-kit/dist/styles.css` — which uses shadcn-style `--primary` / `--background` tokens and does **not** define any `--pe-color-*` variables.

Net effect: every `var(--pe-color-*)` resolved to nothing, so `bg-primary-500` rendered as transparent. The teal hero became white-on-white (visible at https://www.policyengine.org/us/watca right now) and primary accents disappeared across the calculator.

## Fix
Inline the hex values directly in the `@theme` block — values match `@policyengine/design-system` 0.3.0 `tokens.css`, so the visual output is identical to the pre-migration site.

## Verification
- `bun run build` — succeeds
- `next start` locally on `/us/watca` — teal hero with "Working Americans' Tax Cut Act Calculator" in white is visible again; selected tab + accent cards render in teal.

## Wider context
The same bug affects every consumer that migrated from `@policyengine/design-system` to `@policyengine/ui-kit/legacy` via #24-style import-path renames (the legacy shim is JS-only — it doesn't ship a CSS-token compat file). I'll follow up by adding `dist/legacy/tokens.css` to `@policyengine/ui-kit` so the next-affected apps can fix this with a single-line import bump instead of inlining hex.