### PR TITLE
Move PolicyEngine version note to results footnote

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -190,18 +190,6 @@ export default function RootLayout({
       <body>
         <Header />
         <Providers>{children}</Providers>
-        <footer className="border-t border-gray-200 bg-white px-4 py-4 text-center text-xs text-gray-500">
-          Calculations powered by{' '}
-          <a
-            href="https://github.com/PolicyEngine/policyengine.py"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-primary-500 hover:underline"
-          >
-            policyengine
-          </a>
-          {' '}v4.4.4
-        </footer>
       </body>
     </html>
   );

--- a/frontend/components/AggregateImpact.tsx
+++ b/frontend/components/AggregateImpact.tsx
@@ -129,6 +129,16 @@ export default function AggregateImpact({ behavioralResponses, triggered }: Prop
 
       <p className="text-sm text-gray-500 bg-gray-50 rounded-lg px-4 py-3 border border-gray-200">
         These estimates are static: they do not capture behavioral responses such as changes in labor supply, tax avoidance, or migration.
+        {' '}Calculations use{' '}
+        <a
+          href="https://github.com/PolicyEngine/policyengine.py"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-primary-600 hover:underline"
+        >
+          policyengine
+        </a>
+        {' '}v4.4.4.
       </p>
 
       {/* Year selector */}

--- a/tests/test_results_provenance.py
+++ b/tests/test_results_provenance.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_policyengine_layout_has_no_model_provenance_footer():
+    layout = (ROOT / "frontend/app/layout.tsx").read_text()
+
+    assert "policyengine.py" not in layout
+    assert "v4.4.4" not in layout
+
+
+def test_results_footnote_shows_model_provenance():
+    aggregate = (ROOT / "frontend/components/AggregateImpact.tsx").read_text()
+
+    assert "These estimates are static" in aggregate
+    assert "policyengine.py" in aggregate
+    assert "v4.4.4" in aggregate


### PR DESCRIPTION
## Summary\n- remove the model-version note from the global layout footer\n- add policyengine v4.4.4 to the WATCA National Impact results footnote\n- add a regression test for this placement\n\n## Verification\n- uv run --with pytest python -m pytest tests/test_results_provenance.py -q\n- npm run lint\n- npm run build