### PR TITLE
Import @policyengine/ui-kit/theme.css for brand tokens

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,6 +1,7 @@
 /* Fonts loaded via <link> tags in layout.tsx for better performance */
 
 @import "tailwindcss";
+@import "@policyengine/ui-kit/theme.css";
 @import "../node_modules/@policyengine/ui-kit/dist/styles.css";
 
 /*


### PR DESCRIPTION
PolicyEngineShell header uses `--color-teal-*` and `--spacing-header` from theme.css. Without these tokens the gradient renders blank.